### PR TITLE
Docker Sync Prototype

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+COMPOSE_FILE=docker-compose.yml:docker-compose-dev.yml

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,6 @@ yarn-debug.log*
 .env.*
 !.env.development
 !.env.test
+!.env
 /vendor/bundle-dev
+.docker-sync/

--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+if [[ "$OSTYPE" == *"darwin"* ]]; then
+  docker-sync start
+  docker-compose up --detach
+fi
+
 docker-compose run \
    cicd \
    ./bin/_setup

--- a/bin/update
+++ b/bin/update
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+docker-compose down
+docker-sync stop
+docker-sync clean
+
+./bin/bootstrap
+./bin/setup

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+services:
+  cicd:
+    volumes:
+      - cicd-sync:/var/task:nocopy
+
+volumes:
+  cicd-sync:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 services:
   cicd:
     build: .
+    command: tail -f /dev/null
     environment:
       - RUBYOPT=-W0
       - RAILS_ENV=${RAILS_ENV-development}

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,0 +1,4 @@
+version: '2'
+syncs:
+  cicd-sync:
+    src: '.'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,4 @@ require 'rails/test_help'
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors)
-
-  # Add more helper methods to be used by all tests here...
 end


### PR DESCRIPTION
Maybe after many many years the Docker team will have a sane pattern for fast OS X file systems. Once that happens SO MUCH boilerplate of how we deal with Docker can be simplified and we can start to break down the patterns that have been forced on us for years. Containers & MicroVMs are the future and I am looking forward to a day when some age old tooling makes development easier on OS X. 

* https://github.com/docker/for-mac/issues/1592
* https://github.com/docker/roadmap/issues/7

Since using edge Edge2.3.4.0 (with mutagen) will cause other issues and until those issue above are sorted out we needed a bailout. I saw on Twitter where DHH was looking at `docker-sync` boilerplate (https://github.com/EugenMayer/docker-sync-boilerplate/tree/master/default) examples. So I took the time to learn docker-sync with an emphasis on our existing patterns at Custom Ink.  Here is what I came up with. The only sticking point is that you need to do have Ruby installed globally still (not an issue) and do a `gem install docker-sync` which will be easy to do in our global tooling.

The way this is setup is to yield to the Spacklepunch (https://faasandfurious.com/122) when it happens. It will happen, eventually Docker on Mac will not suck. And when it does, we should set ourselves up to easily remove these hacks. I think this does a good job at that.

http://docker-sync.io